### PR TITLE
Remove DejaVu Sans Mono from CSS stacks; major bump celine & libertine

### DIFF
--- a/bibhtml/index.html
+++ b/bibhtml/index.html
@@ -284,7 +284,7 @@
 
   <style>
     .fwbish {
-      font-family: "FontWithASyntaxHighlighter", 'DejaVu Sans Mono', Menlo, Consolas, monospace;
+      font-family: "FontWithASyntaxHighlighter", Menlo, Consolas, monospace;
       font-feature-settings: "colr", "calt";
       color: #eee;
       font-size: 0.87rem;

--- a/cdn-starter-explicit-imports.html
+++ b/cdn-starter-explicit-imports.html
@@ -6,7 +6,7 @@
   <title>@celine/celine CDN starter (explicit imports)</title>
 
   <script type="module">
-    import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@7.2.0';
+    import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@8.0.0';
     import * as Inputs from 'https://esm.run/@observablehq/inputs@0.12.0';
     import * as htl from 'https://esm.run/htl@0.3.1';
 
@@ -18,9 +18,9 @@
     registerScriptReevaluationOnBlur(document, /*class=*/'echo');
   </script>
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@7.2.0/cell.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@8.0.0/cell.css" />
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css" />
 </head>
 <body>
   <main>

--- a/cdn-starter-implicit-imports.html
+++ b/cdn-starter-implicit-imports.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@celine/celine CDN starter (implicit imports)</title>
 
-  <script type="module" src="https://esm.sh/jsr/@celine/celine@7.2.0/global"></script>
+  <script type="module" src="https://esm.sh/jsr/@celine/celine@8.0.0/global"></script>
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@7.2.0/cell.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@8.0.0/cell.css" />
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css" />
 </head>
 <body>
   <main>

--- a/cdn-starter.html
+++ b/cdn-starter.html
@@ -6,7 +6,7 @@
   <title>@celine/celine CDN starter</title>
 
   <script type="module">
-    import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@7.2.0';
+    import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@8.0.0';
     import * as Inputs from 'https://esm.run/@observablehq/inputs@0.12.0';
     import * as htl from 'https://esm.run/htl@0.3.1';
 
@@ -18,9 +18,9 @@
     registerScriptReevaluationOnBlur(document, /*class=*/'echo');
   </script>
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@7.2.0/cell.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/celine@8.0.0/cell.css" />
 
-  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css" />
+  <link rel="stylesheet" href="https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css" />
 </head>
 <body>
   <main>

--- a/celine/celine.bundle.mjs
+++ b/celine/celine.bundle.mjs
@@ -1,7 +1,7 @@
 import {
   CelineModule,
   registerScriptReevaluationOnBlur,
-} from "https://esm.sh/jsr/@celine/celine@7.2.0";
+} from "https://esm.sh/jsr/@celine/celine@8.0.0";
 import * as Inputs from "https://esm.run/@observablehq/inputs@0.12.0";
 import * as htl from "https://esm.run/htl@0.3.1";
 

--- a/celine/cell.css
+++ b/celine/cell.css
@@ -15,7 +15,7 @@
 
 /** keep in sync with libertine.css */
 :root {
-  --monospace-font-family: 'DejaVu Sans Mono', Menlo, Consolas, monospace;
+  --monospace-font-family: Menlo, Consolas, monospace;
   --mono_fonts: 82%/1.5 var(--monospace-font-family);
 }
 

--- a/celine/changelog.xml
+++ b/celine/changelog.xml
@@ -8,6 +8,16 @@
   <id>https://maxbo.me/celine/celine/changelog.xml</id>
 
   <entry>
+    <title>8.0.0</title>
+    <link href="https://jsr.io/@celine/celine@8.0.0"/>
+    <id>https://jsr.io/@celine/celine@8.0.0</id>
+    <updated>2026-04-14T00:00:00Z</updated>
+    <summary type="html"><![CDATA[
+      <strong>Breaking:</strong> <code>cell.css</code> <code>--monospace-font-family</code> no longer prefers <cite>DejaVu Sans Mono</cite> (TTF webfonts are unreliable in Safari); it now matches <cite>libertine.css</cite> with <code>Menlo, Consolas, monospace</code>.
+    ]]></summary>
+  </entry>
+
+  <entry>
     <title>7.2.0</title>
     <link href="https://jsr.io/@celine/celine@7.2.0"/>
     <id>https://jsr.io/@celine/celine@7.2.0</id>

--- a/celine/deno.json
+++ b/celine/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@celine/celine",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "exports": {
     ".": "./mod.ts",
     "./global": "./global.mjs"

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
       <td class="width-auto"><a href="https://jsr.io/@celine/celine">jsr.io/<wbr>@celine/<wbr>celine</a> + <a href="https://jsr.io/@celine/celine/doc">/docs</a></td>
       <th>Version</th>
       <!-- these should be updated to the best of your ability -->
-      <td class="width-min"><a href="https://jsr.io/@celine/celine/versions" id="version">7.2.0</a>, <time  id="updated">Apr 13 2026</time></td>
+      <td class="width-min"><a href="https://jsr.io/@celine/celine/versions" id="version">8.0.0</a>, <time  id="updated">Apr 14 2026</time></td>
     </tr>
     <script type="module">
       fetch("https://npm.jsr.io/@jsr/celine__celine")
@@ -228,7 +228,7 @@
 <p>Add the following <code>&lt;script&gt;</code> element to your HTML file's <code>&lt;head&gt;</code> block:</p> 
 
 <pre class="echo" style="margin-bottom: 1ch;">&lt;script type=&quot;module&quot;&gt;
-import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@7.2.0';
+import { CelineModule, registerScriptReevaluationOnBlur } from 'https://esm.sh/jsr/@celine/celine@8.0.0';
 import * as Inputs from 'https://esm.run/@observablehq/inputs@0.12.0';
 import * as htl from 'https://esm.run/htl@0.3.1';
 
@@ -246,7 +246,7 @@ registerScriptReevaluationOnBlur(document, /*class=*/'echo');
 <pre class="echo" style="margin-bottom: 1ch;">
 &lt;link 
   rel=&quot;stylesheet&quot; 
-  href=&quot;https://esm.sh/jsr/@celine/celine@7.2.0/cell.css&quot; /&gt;
+  href=&quot;https://esm.sh/jsr/@celine/celine@8.0.0/cell.css&quot; /&gt;
 </pre>
 
 <p>
@@ -256,7 +256,7 @@ You may want to include <cite>@celine/celine</cite>'s drop-in stylesheet, <a hre
 <pre class="echo" style="margin-bottom: 1ch;">
 &lt;link 
   rel=&quot;stylesheet&quot; 
-  href=&quot;https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css&quot; /&gt;
+  href=&quot;https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css&quot; /&gt;
 </pre>
 
 <h3><a href="#via-cdn-implicit-imports" id="via-cdn-implicit-imports"></a>via CDN, with implicit imports</h3>
@@ -272,7 +272,7 @@ You may want to include <cite>@celine/celine</cite>'s drop-in stylesheet, <a hre
 </p>
 
 <pre class="echo" style="margin-bottom: 1ch;">
-&lt;script type=&quot;module&quot; src=&quot;https://esm.sh/jsr/@celine/celine@7.2.0/global&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;module&quot; src=&quot;https://esm.sh/jsr/@celine/celine@8.0.0/global&quot;&gt;&lt;/script&gt;
 </pre>
 
 <p>
@@ -284,7 +284,7 @@ You may want to include <cite>@celine/celine</cite>'s drop-in stylesheet, <a hre
 <pre class="echo" style="margin-bottom: 1ch;">
 &lt;link 
   rel=&quot;stylesheet&quot; 
-  href=&quot;https://esm.sh/jsr/@celine/celine@7.2.0/cell.css&quot; /&gt;
+  href=&quot;https://esm.sh/jsr/@celine/celine@8.0.0/cell.css&quot; /&gt;
 </pre>
 
 <p>
@@ -294,7 +294,7 @@ You may want to include <cite>@celine/celine</cite>'s drop-in stylesheet, <a hre
 <pre class="echo" style="margin-bottom: 1ch;">
 &lt;link 
   rel=&quot;stylesheet&quot; 
-  href=&quot;https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css&quot; /&gt;
+  href=&quot;https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css&quot; /&gt;
 </pre>
 
 

--- a/libertine/changelog.xml
+++ b/libertine/changelog.xml
@@ -8,6 +8,16 @@
   <id>https://maxbo.me/celine/libertine/changelog.xml</id>
 
   <entry>
+    <title>26.0.0</title>
+    <link href="https://jsr.io/@celine/libertine@26.0.0"/>
+    <id>https://jsr.io/@celine/libertine@26.0.0</id>
+    <updated>2026-04-14T00:00:00Z</updated>
+    <summary type="html"><![CDATA[
+      <strong>Breaking:</strong> <code>libertine.css</code> no longer registers <cite>DejaVu Sans Mono</cite> or lists it in <code>--monospace-font-family</code> (bundled TTF files are unreliable in Safari). Monospace UI falls back to <code>Menlo, Consolas, monospace</code>. The <code>fonts/dejavu/</code> directory remains in the package for optional local use.
+    ]]></summary>
+  </entry>
+
+  <entry>
     <title>25.0.0</title>
     <link href="https://jsr.io/@celine/libertine@25.0.0"/>
     <id>https://jsr.io/@celine/libertine@25.0.0</id>

--- a/libertine/deno.json
+++ b/libertine/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@celine/libertine",
-  "version": "25.0.0",
+  "version": "26.0.0",
   "license": "MIT",
   "exports": "./mod.ts"
 }

--- a/libertine/index.html
+++ b/libertine/index.html
@@ -87,7 +87,7 @@
         <th>JSR</th>
         <td class="width-auto"><a href="https://jsr.io/@celine/libertine">jsr.io/<wbr>@celine/<wbr>libertine</a> + <a href="https://jsr.io/@celine/libertine/doc">/docs</a></td>
         <th>Version</th>
-        <td class="width-min"><a href="https://jsr.io/@celine/libertine/versions" id="version">25.0.0</a>, <time  id="updated">Apr 13 2026</time></td>
+        <td class="width-min"><a href="https://jsr.io/@celine/libertine/versions" id="version">26.0.0</a>, <time  id="updated">Apr 14 2026</time></td>
       </tr>
       <script type="module">
         fetch("https://npm.jsr.io/@jsr/celine__libertine")
@@ -111,7 +111,7 @@
 <pre class="echo" style="margin-bottom: 1ch;" id="import">
 &lt;link 
   rel=&quot;stylesheet&quot; 
-  href=&quot;https://esm.sh/jsr/@celine/libertine@25.0.0/libertine.css&quot; /&gt;
+  href=&quot;https://esm.sh/jsr/@celine/libertine@26.0.0/libertine.css&quot; /&gt;
 </pre>
 
 <h3><a href="#via-local-file" id="via-local-file"></a>via local file</h3>

--- a/libertine/libertine.css
+++ b/libertine/libertine.css
@@ -1,40 +1,8 @@
 @import url('./fonts/Libertinus/documentation/libertinus.css');
 
-@font-face {
-  font-family: 'DejaVu Sans Mono';
-  src: url('./fonts/dejavu/DejaVuSansMono.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'DejaVu Sans Mono';
-  src: url('./fonts/dejavu/DejaVuSansMono-Bold.ttf') format('truetype');
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'DejaVu Sans Mono';
-  src: url('./fonts/dejavu/DejaVuSansMono-Oblique.ttf') format('truetype');
-  font-weight: 400;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'DejaVu Sans Mono';
-  src: url('./fonts/dejavu/DejaVuSansMono-BoldOblique.ttf') format('truetype');
-  font-weight: 700;
-  font-style: italic;
-  font-display: swap;
-}
-
 /* keep in sync with cell.css */
 :root {
-  --monospace-font-family: 'DejaVu Sans Mono', Menlo, Consolas, monospace;
+  --monospace-font-family: Menlo, Consolas, monospace;
   --mono_fonts: 82%/1.5 var(--monospace-font-family);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Safari does not reliably render the bundled DejaVu Sans Mono TTF webfonts, so monospace styling fell back inconsistently. This change removes DejaVu from the active font stack while keeping the `fonts/dejavu/` files in the repository for optional local use.

## Changes

- **libertine.css**: Removed the four `@font-face` rules for DejaVu Sans Mono and set `--monospace-font-family` to `Menlo, Consolas, monospace` (in sync with cell.css).
- **cell.css**: Updated `--monospace-font-family` to match.
- **Versions**: `@celine/celine` **8.0.0**, `@celine/libertine` **26.0.0** (semver major for breaking typography).
- **Docs / examples**: Updated pinned JSR URLs in `index.html`, `libertine/index.html`, CDN starter HTML files, and `celine/celine.bundle.mjs`. Added changelog entries in `celine/changelog.xml` and `libertine/changelog.xml`.
- **bibhtml/index.html**: Demo inline style updated so the fallback stack matches (no DejaVu in the stack).

## Verification

`deno check` was attempted after installing Deno; module resolution for npm imports from the workspace root still failed in this environment (TS2307 for `@observablehq/*`). No TypeScript source files were modified beyond the bundle URL string.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a71b12a7-685d-44af-bea6-db42c40ea423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a71b12a7-685d-44af-bea6-db42c40ea423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

